### PR TITLE
[stream-functionality] Implementation of backend support

### DIFF
--- a/Warble/CommandLine/main.cc
+++ b/Warble/CommandLine/main.cc
@@ -38,6 +38,24 @@ DEFINE_bool(
 DEFINE_bool(hook, false, "Initializes all functions. Enter as -hook");
 DEFINE_bool(unhook, false, "Uninitializes all functions. Enter as -unhook");
 
+// This method will extract hashtag('substring begins with “#” 
+// and has one or more non-blank characters after it.') from raw string
+std::string FuncClient::ProcessHashtag(const std::string& raw_hashtag) {
+  std::string hashtag = "";
+  bool meet_pound_sign = false;
+  for (const char& c : raw_hashtag) {
+    if (meet_pound_sign) {
+      if (c == ' ') {
+        break;
+      }
+      hashtag += c;
+    } else if (c == '#') {
+      meet_pound_sign = true;
+    }
+  }
+  return hashtag;
+}
+
 void FuncClient::RegisterUser(const std::string &username) {
   // Objects being passing into stub
   grpc::ClientContext context;
@@ -286,11 +304,17 @@ void FuncClient::Stream(std::string hashtag) {
   // Record length of vector as start index to read.
   // This deals with the situation of identical hashtag
   // queried by several users. 
+  std::string processed_hashtag = ProcessHashtag(hashtag);
+  if (processed_hashtag.length() == 0) {
+    std::cout << "Invalid hashtag, Hashtag format : <#HASHTAG>" << std::endl;
+    return;
+  }
+
   std::cout << "Start receiving streaming message with hashtag : " << 
-    hashtag << "..." << std::endl;
+    processed_hashtag << "..." << std::endl;
   grpc::ClientContext context;
   warble::StreamRequest streamrequest;
-  streamrequest.set_hashtag(hashtag);
+  streamrequest.set_hashtag(processed_hashtag);
 
   // Pack StreamRequest into an eventrequest payload
   func::EventRequest request;
@@ -318,7 +342,7 @@ void FuncClient::Stream(std::string hashtag) {
     func::EventRequest event_request;
     warble::StreamRequest streamrequest;
     google::protobuf::Any payload;
-    streamrequest.set_hashtag(hashtag);
+    streamrequest.set_hashtag(processed_hashtag);
     payload.PackFrom(streamrequest);
     *event_request.mutable_payload() = payload;
     event_request.set_event_type(kStream);
@@ -330,12 +354,11 @@ void FuncClient::Stream(std::string hashtag) {
       if(event_reply.payload().UnpackTo(&streamreply)) {
         while (stream_start_idx < streamreply.warbles().size()) {
           warble::Warble current_warble = streamreply.warbles()[stream_start_idx];
-          std::cout << "[Warble: " << stream_start_idx <<"] with hashtag <" << hashtag << "> is streamed!\n";
+          std::cout << "[Warble: " << stream_start_idx <<"] with hashtag <" << processed_hashtag << "> is streamed!\n";
           std::cout << "ID: " << current_warble.id() << std::endl;
           std::cout << "Author: " << current_warble.username() << std::endl;
           std::cout << "Time Posted: " << current_warble.timestamp().seconds() << std::endl;
-          std::cout << "Text: " << current_warble.text() << std::endl;
-          std::cout << std::endl << std::endl;
+          std::cout << "Text: " << current_warble.text() << std::endl << std::endl;
           stream_start_idx ++;
         }
       }

--- a/Warble/CommandLine/main.cc
+++ b/Warble/CommandLine/main.cc
@@ -286,8 +286,9 @@ void FuncClient::Stream(std::string hashtag) {
   // Record length of vector as start index to read.
   // This deals with the situation of identical hashtag
   // queried by several users. 
+  std::cout << "Start receiving streaming message with hashtag : " << 
+    hashtag << "..." << std::endl;
   grpc::ClientContext context;
-
   warble::StreamRequest streamrequest;
   streamrequest.set_hashtag(hashtag);
 
@@ -297,7 +298,6 @@ void FuncClient::Stream(std::string hashtag) {
   google::protobuf::Any payload;
   payload.PackFrom(streamrequest);
   *request.mutable_payload() = payload;
-
   // Unpack response from GRPC
   func::EventReply reply;
   warble::StreamReply streamreply;
@@ -314,15 +314,20 @@ void FuncClient::Stream(std::string hashtag) {
   // Stream warbles from kvstore every 100 ms.
   int sleep_time = 100;
   while (true) {
+    grpc::ClientContext context;
+    func::EventRequest event_request;
+    warble::StreamRequest streamrequest;
     google::protobuf::Any payload;
+    streamrequest.set_hashtag(hashtag);
     payload.PackFrom(streamrequest);
-    *request.mutable_payload() = payload;
+    *event_request.mutable_payload() = payload;
+    event_request.set_event_type(kStream);
     // Unpack response from GRPC
-    func::EventReply reply;
+    func::EventReply event_reply;
     warble::StreamReply streamreply;
-    grpc::Status status = stub_->event(&context, request, &reply);
+    grpc::Status status = stub_->event(&context, event_request, &event_reply);
     if(status.ok()) {
-      if(reply.payload().UnpackTo(&streamreply)) {
+      if(event_reply.payload().UnpackTo(&streamreply)) {
         while (stream_start_idx < streamreply.warbles().size()) {
           warble::Warble current_warble = streamreply.warbles()[stream_start_idx];
           std::cout << "[Warble: " << stream_start_idx <<"] with hashtag <" << hashtag << "> is streamed!\n";
@@ -385,6 +390,8 @@ int main(int argc, char *argv[]) {
     func_client.Profile(FLAGS_user);
   } else if (!FLAGS_follow.empty()) {
     func_client.Follow(FLAGS_user, FLAGS_follow);
+  } else if (!FLAGS_stream.empty()) {
+    func_client.Stream(FLAGS_stream);
   }
 
   google::protobuf::ShutdownProtobufLibrary();

--- a/Warble/CommandLine/main.h
+++ b/Warble/CommandLine/main.h
@@ -66,4 +66,5 @@ public:
 private:
   std::unique_ptr<func::KeyValueStore::Stub> stub_;
   std::unordered_map<std::string, WarbleTypes> typemap_;
+  std::string ProcessHashtag(const std::string& raw_hashtag);
 };

--- a/Warble/KVStore/KVWrapper.cc
+++ b/Warble/KVStore/KVWrapper.cc
@@ -110,7 +110,18 @@ public:
   // Parameters: hashtag.
   // Return: A vector of warbles, which contain hashtag in their text.
   std::vector<std::string> StreamGetRequest(std::string hashtag) {
-    // to be completed
+    grpc::ClientContext context;
+    kvstore::GetStreamRequest request;
+    request.set_hashtag(hashtag);
+    kvstore::GetStreamReply reply;
+
+    grpc::Status status = stub_->StreamGet(&context, request, &reply);
+    std::vector<std::string> serialized_warbles_vec;
+    for (std::string serialized_warble : reply.serialized_warbles()) {
+      serialized_warbles_vec.push_back(serialized_warble);
+    }
+    
+    return serialized_warbles_vec;
   }
 
   // StreamPutRequest method is used to add warble to hashtag. 
@@ -120,6 +131,23 @@ public:
   //             serialized_warble: warble after serialization.
   void StreamPutRequest(std::vector<std::string> split_warble_texts, std::string serialized_warble) {
     //to be completed
+    if (split_warble_texts.size() == 0) {
+      return;
+    }
+    
+    for (std::string warble_text : split_warble_texts) {
+      grpc::ClientContext context;
+      kvstore::PutStreamRequest request;
+      request.set_warble_text(warble_text);
+      request.set_serialized_warble(serialized_warble);
+      kvstore::PutStreamReply reply;
+      grpc::Status status = stub_->StreamPut(&context, request, &reply);
+      if (!status.ok()) {
+        std::cout << status.error_code() << ": " << status.error_message()
+                  << std::endl;
+        break;
+      }
+    }
   }
 
 private:

--- a/Warble/KVStore/kvstore_server.cc
+++ b/Warble/KVStore/kvstore_server.cc
@@ -35,15 +35,20 @@ grpc::Status KeyValueStoreImpl::remove(grpc::ServerContext *context,
 grpc::Status KeyValueStoreImpl::StreamGet(grpc::ServerContext *context,
                          const kvstore::GetStreamRequest *request,
                          kvstore::GetStreamReply *reply) {
-  //to be completed
+  std::string hashtag = request->hashtag();
+  std::vector<std::string> serialized_warbles = kvstore_.GetStream(hashtag);
+  for (std::string serialized_warble : serialized_warbles) {
+     std::string* warble = reply->add_serialized_warbles();
+     *warble = serialized_warble;
+  }
+  return grpc::Status::OK;
 }
 
 grpc::Status KeyValueStoreImpl::StreamPut(grpc::ServerContext *context,
                          const kvstore::PutStreamRequest *request,
                          kvstore::PutStreamReply *reply) {
-  //to be completed
-  //for each text in request.warble_texts(): 
-  //if it's a hashtag, add request.serialized_warble() to hashtag_db_
+  kvstore_.PutStream(request->warble_text(), request->serialized_warble());
+  return grpc::Status::OK;
 }
 
 void RunServer() {

--- a/Warble/KVStore/kvstore_server.h
+++ b/Warble/KVStore/kvstore_server.h
@@ -41,7 +41,8 @@ public:
                          kvstore::GetStreamReply *reply) override;
   
   // Function that calls kvstore to put serialized warbles to db
-  // if the text of warble contains some hashtag.
+  // if the word is a hashtag, then kvstore_ will put 
+  // serialized warble to db.
   // Parameters: GRPC server context, PutStream request, PutStream reply
   // Return: GRPC status indicating whether put process is successful.
   grpc::Status StreamPut(grpc::ServerContext *context,

--- a/Warble/KVStore/warble_code.cc
+++ b/Warble/KVStore/warble_code.cc
@@ -1,5 +1,35 @@
 #include "warble_code.h"
 
+// This method split warble text into a vector of unique words.
+// Input : warlbe text in string format.
+// Output: A vector with unique words, which contains 
+// all unique split warble words. 
+std::vector<std::string> CreateUniqueWords(const std::string& warble_text) {
+  std::unordered_set<std::string> warble_word_set;
+  std::vector<std::string> split_warble_text_vec;
+  std::string word = "";
+  for (auto ch : warble_text) {
+    if (ch == ' ') {
+      if (word.length() != 0) {
+        warble_word_set.insert(word);
+        word = "";
+      }
+    } else {
+      word += ch;
+    }
+  }
+
+  if (word.length() > 0) {
+    warble_word_set.insert(word);
+  }
+
+  for (std::string warble_word : warble_word_set) {
+    split_warble_text_vec.push_back(warble_word);
+  }
+
+  return split_warble_text_vec;
+}
+
 grpc::Status WarbleCode::CreateUser(const google::protobuf::Any &request,
                                     google::protobuf::Any *reply) {
   // If user already doesn't exist
@@ -80,7 +110,8 @@ grpc::Status WarbleCode::CreateWarble(const google::protobuf::Any &request,
 
     // After generating serialized warble, kvstore_->StreamPutRequest should
     // be called here to associate serialzed warble with hashtags.
-    // to be completed...
+    std::vector<std::string> split_warble_texts = CreateUniqueWords(warble_request.text());
+    kvstore_->StreamPutRequest(split_warble_texts, newwarble_value);
 
     warble::WarbleReply warblereply;
     *warblereply.mutable_warble() = new_warble;
@@ -231,7 +262,7 @@ grpc::Status WarbleCode::Stream(const google::protobuf::Any &request,
     for (std::string serialized_warble : serialized_warbles) {
       warble::Warble warble;
       warble.ParseFromString(serialized_warble);
-      *streamreply.add_warbles() = warble;
+      *(streamreply.add_warbles()) = warble;
     }
     reply->PackFrom(streamreply);
     return grpc::Status::OK;

--- a/Warble/KVStore/warble_code.h
+++ b/Warble/KVStore/warble_code.h
@@ -14,6 +14,8 @@
 #include <grpcpp/server_context.h>
 #include <sstream>
 #include <thread>
+#include <bits/stdc++.h> 
+
 
 using google::protobuf::Any;
 

--- a/Warble/database/kvstore_database.cc
+++ b/Warble/database/kvstore_database.cc
@@ -22,9 +22,9 @@ std::string KVStoreDb::Get(const std::string key) {
 // Remove data from the database from a given key
 void KVStoreDb::Remove(std::string key) { db_.erase(key); }
 
-void KVStoreDb::PutStream(const std::string hashtag, const std::string serialized_warble) {
-  if (hashtag_db_.find(hashtag) != hashtag_db_.end()) {
-     hashtag_db_[hashtag].push_back(serialized_warble);
+void KVStoreDb::PutStream(const std::string warble_text_word, const std::string serialized_warble) {
+  if (hashtag_db_.find(warble_text_word) != hashtag_db_.end()) {
+     hashtag_db_[warble_text_word].push_back(serialized_warble);
   }
 }
 

--- a/Warble/database/kvstore_database.cc
+++ b/Warble/database/kvstore_database.cc
@@ -22,11 +22,18 @@ std::string KVStoreDb::Get(const std::string key) {
 // Remove data from the database from a given key
 void KVStoreDb::Remove(std::string key) { db_.erase(key); }
 
-void PutStream(const std::string hashtag, const std::string serialized_warble) {
-  //to be completed
+void KVStoreDb::PutStream(const std::string hashtag, const std::string serialized_warble) {
+  if (hashtag_db_.find(hashtag) != hashtag_db_.end()) {
+     hashtag_db_[hashtag].push_back(serialized_warble);
+  }
 }
 
-std::vector<std::string> GetStream(const std::string hashtag) {
-  //to be completed
+std::vector<std::string> KVStoreDb::GetStream(const std::string hashtag) {
+	 if (hashtag_db_.find(hashtag) == hashtag_db_.end()) {
+	   hashtag_db_.insert({hashtag, {}});
+	   return {};
+	 }
+
+	 return hashtag_db_[hashtag];
 }
 

--- a/Warble/database/kvstore_database.h
+++ b/Warble/database/kvstore_database.h
@@ -26,8 +26,8 @@ public:
   void Remove(std::string key);
 
   // Put serialized_warble to corresponding vector of hashtag
-  // Parameters: hashtag as key, serialized_warble as value.
-  void PutStream(const std::string hashtag, const std::string serialized_warble);
+  // Parameters: warble_text_word as key, serialized_warble as value.
+  void PutStream(const std::string warble_text_word, const std::string serialized_warble);
 
   // Getting a vector of unique serialized_warbles, which 
   // contain hashtag in their text.

--- a/Warble/database/kvstore_database.h
+++ b/Warble/database/kvstore_database.h
@@ -25,14 +25,14 @@ public:
   // Return: void
   void Remove(std::string key);
 
-  // Put serialized_warble to corresponding set of hashtag
+  // Put serialized_warble to corresponding vector of hashtag
   // Parameters: hashtag as key, serialized_warble as value.
   void PutStream(const std::string hashtag, const std::string serialized_warble);
 
-  // Getting a set of unique serialized_warbles, which 
+  // Getting a vector of unique serialized_warbles, which 
   // contain hashtag in their text.
   // Parameters: hashtag as key
-  // Return: a set of distinct serialized warbles.
+  // Return: a vector of distinct serialized warbles.
   std::vector<std::string> GetStream(const std::string hashtag);
 
 

--- a/Warble/protos/kvstore.proto
+++ b/Warble/protos/kvstore.proto
@@ -28,16 +28,16 @@ message RemoveReply {
 }
 
 message GetStreamRequest {
-  string hashtag = 1;
+  bytes hashtag = 1;
 }
 
 message GetStreamReply {
-  repeated string serialized_warbles = 1;
+  repeated bytes serialized_warbles = 1;
 }
 
 message PutStreamRequest {
-  repeated string warble_texts = 1;
-  string serialized_warble = 2;
+  bytes warble_text = 1;
+  bytes serialized_warble = 2;
 }
 
 message PutStreamReply {


### PR DESCRIPTION
This pull request implements backend support for stream functionality. Hashtag will be pre-processed before passing to query.

Stream functionality should work now by executing:
`./main -user "USER_NAME" -stream "#HASHTAG"`
The function will continue stream warbles until user manually suspends it. 

Please see [design doc](https://docs.google.com/document/d/1j5zE4UF_ESlBAknUjUv5lB6YEiHfve_jUmhYeXQma1Q/edit#) for more details